### PR TITLE
Change step labels to use names

### DIFF
--- a/internal/utils/cloudbuild.go
+++ b/internal/utils/cloudbuild.go
@@ -61,7 +61,7 @@ func BuildStepsToDAG(steps []*cloudbuild.BuildStep) *cgraph.Graph {
 
 	var nodeList []*cgraph.Node
 	for idx, step := range steps {
-		name := step.Id
+		name := step.Name
 		if name == "" {
 			name = fmt.Sprintf("Step %d", idx)
 		}


### PR DESCRIPTION
Pretty sure this is the intended behaviour, Here's the output I'd expect (Without this change merged)

![example](https://user-images.githubusercontent.com/603334/79402626-72eadc00-7f5a-11ea-85aa-70034f95d60c.jpg)

Compared to what it renders today

![bad-example](https://user-images.githubusercontent.com/603334/79402660-88f89c80-7f5a-11ea-8c40-4b401497d5a8.jpg)

