### PR TITLE
Drop 1.24 support and update codecov action

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,7 +14,6 @@ jobs:
         - macOS-latest
         - windows-latest
         go-version:
-        - '1.24'
         - '1.25'
     runs-on: ${{ matrix.os }}
     steps:
@@ -33,8 +32,9 @@ jobs:
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v4
       with:
+        token: ${{ secrets.CODECOV_TOKEN }}
         files: coverage.out
-        fail_ci_if_error: true
+        fail_ci_if_error: tru
         verbose: true
     - name: Build Artifacts
       run: |

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -28,14 +28,7 @@ jobs:
         go mod download
     - name: Test
       run: |
-        go test -v -coverprofile=coverage.out ./...
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v4
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        files: coverage.out
-        fail_ci_if_error: false
-        verbose: true
+        go test -v ./...
     - name: Build Artifacts
       run: |
         go build -ldflags="-s -w" -o gcb-visualizer

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -27,9 +27,8 @@ jobs:
       run: |
         go mod download
     - name: Test
-      shell: bash
       run: |
-        go test -v ./... -coverprofile=coverage.out
+        go test -v -coverprofile=coverage.out ./...
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v4
       with:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -34,7 +34,7 @@ jobs:
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: coverage.out
-        fail_ci_if_error: true
+        fail_ci_if_error: false
         verbose: true
     - name: Build Artifacts
       run: |

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -27,14 +27,15 @@ jobs:
       run: |
         go mod download
     - name: Test
+      shell: bash
       run: |
-        go test -coverprofile=coverage.out ./... -v
+        go test -v ./... -coverprofile=coverage.out
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: coverage.out
-        fail_ci_if_error: tru
+        fail_ci_if_error: true
         verbose: true
     - name: Build Artifacts
       run: |


### PR DESCRIPTION
The build has been failed after the upgrade
To fix it, I have to drop 1.24 and also codecov support